### PR TITLE
remove unused react-window package

### DIFF
--- a/packages/typeslayer/package.json
+++ b/packages/typeslayer/package.json
@@ -37,7 +37,6 @@
     "echarts-for-react": "^3.0.5",
     "react": "19.2.1",
     "react-dom": "19.2.1",
-    "react-window": "^2.2.3",
     "shiki": "^3.19.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,9 +90,6 @@ importers:
       react-dom:
         specifier: 19.2.1
         version: 19.2.1(react@19.2.1)
-      react-window:
-        specifier: ^2.2.3
-        version: 2.2.3(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       shiki:
         specifier: ^3.19.0
         version: 3.19.0
@@ -1628,12 +1625,6 @@ packages:
     peerDependencies:
       react: '>=16.6.0'
       react-dom: '>=16.6.0'
-
-  react-window@2.2.3:
-    resolution: {integrity: sha512-gTRqQYC8ojbiXyd9duYFiSn2TJw0ROXCgYjenOvNKITWzK0m0eCvkUsEUM08xvydkMh7ncp+LE0uS3DeNGZxnQ==}
-    peerDependencies:
-      react: ^18.0.0 || ^19.0.0
-      react-dom: ^18.0.0 || ^19.0.0
 
   react@19.2.1:
     resolution: {integrity: sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==}
@@ -3407,11 +3398,6 @@ snapshots:
       dom-helpers: 5.2.1
       loose-envify: 1.4.0
       prop-types: 15.8.1
-      react: 19.2.1
-      react-dom: 19.2.1(react@19.2.1)
-
-  react-window@2.2.3(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
-    dependencies:
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
 


### PR DESCRIPTION
The react-window package was introduced in this commit:
https://github.com/dimitropoulos/typeslayer/commit/dc2410d309c7f1d3a301ea841c128f88971ec2ef

However, it appears that react-window has never actually been used in the codebase since that introduction. This PR removes the unused dependency to simplify the project and reduce bundle size.
