### PR TITLE
Fix Git Bash path escaping

### DIFF
--- a/packages/typeslayer/src-tauri/src/app_data/mod.rs
+++ b/packages/typeslayer/src-tauri/src/app_data/mod.rs
@@ -239,8 +239,9 @@ impl AppData {
 
         args.push("--eval");
 
-        // Only here to satisfy lifetimes. Super let when?
         let compiler_variant = self.settings.typescript_compiler_variant;
+
+        // Only here to satisfy lifetimes. Super let when?
         let compiler_require = format!(
             r#""require('{}/bin/{}')""#,
             compiler_variant.npm_package(),


### PR DESCRIPTION
I was initially a bit hesitant to make `quote_if_needed` always use Windows escaping but after auditing we only ever run commands in `cmd`.

If that changes we'll potentially need to have two forms of quoting due to Git Bash. Annoying.