### PR TITLE
Fix perfetto trace not reloading after re-running analytics

### DIFF
--- a/packages/typeslayer/src/hooks/tauri-hooks.ts
+++ b/packages/typeslayer/src/hooks/tauri-hooks.ts
@@ -608,6 +608,11 @@ export const useGenerateAll = () => {
     onMutate: async () => {
       queryClient.invalidateQueries();
     },
+    onSettled: async () => {
+      queryClient.invalidateQueries({
+        'queryKey': ['trace_json']
+      })
+    }
   });
 };
 


### PR DESCRIPTION
Since the `onMutate` hook gets called before the mutation, thus before results are cleared, so I assume we end up reloading the old trace json somewhere before the new version gets written to disk.

This leads to the trace json not getting updated after re-running diagnostics and providing stale data.

I wonder if this also affects other code-paths or not, but I haven't seen similar staleness issues on other panels, so I only added a targeted invalidation when the generate query settles